### PR TITLE
Support for ogdc-runner utilization of argo/hera.

### DIFF
--- a/recipes/sea-ice-conc/recipe.sh
+++ b/recipes/sea-ice-conc/recipe.sh
@@ -3,10 +3,10 @@
 # workflow step.
 
 # First, unscale the data back to percentages (0-100)
-gdal_calc.py --calc "A / 10.0" -A {input_dir}/*.tif --outfile={output_dir}/downscaled.tif
+gdal_calc.py --calc "A / 10.0" -A /input_dir/*.tif --outfile=/output_dir/sic_as_percents.tif
 # Reproject the data from its native EPSG:3411 to EPSG:3413
-gdalwarp -t_srs "EPSG:3413" -r bilinear {input_dir}/downsampled.tif {output_dir}/reprojected.tif
+gdalwarp -t_srs "EPSG:3413" -r bilinear /input_dir/sic_as_percents.tif /output_dir/reprojected.tif
 # Add tiling and compression
-gdal_translate -o TILED=YES -co COMPRESS=DEFLATE -co PREDICTOR=2 {input_dir}/tiled_and_compressed.tif
+gdal_translate -co TILED=YES -co COMPRESS=DEFLATE -co PREDICTOR=2 /input_dir/reprojected.tif /output_dir/tiled_and_compressed.tif
 # Add overviews for visualization performance
-cp {input_dir}/tiled_and_compressed.tif {output_dir}/with_overviews.tif && gdaladdo -r average {output_dir}/with_overviews.tif  2 4 8 16
+cp /input_dir/tiled_and_compressed.tif /output_dir/with_overviews.tif && gdaladdo -r average /output_dir/with_overviews.tif  2 4 8 16

--- a/recipes/seal-tags/recipe.sh
+++ b/recipes/seal-tags/recipe.sh
@@ -1,4 +1,5 @@
 # WARNING: This is not a real shell script, although it is meant to look and
 # feel like one. Each line, unless it starts with #, is interpreted as a
 # workflow step.
-ogr2ogr -lco ENCODING=UTF-8 -t_srs "EPSG:3413" -makevalid -s_srs "EPSG:4326" -oo X_POSSIBLE_NAMES=Longitude -oo Y_POSSIBLE_NAMES=Latitutde {output_dir}/ct71_ODV_epsg3413.gpkg {input_dir}/ct71_ODV.csv
+
+ogr2ogr -lco ENCODING=UTF-8 -t_srs "EPSG:3413" -makevalid -s_srs "EPSG:4326" -oo X_POSSIBLE_NAMES=Longitude -oo Y_POSSIBLE_NAMES=Latitutde /output_dir/ct71_ODV_epsg3413.gpkg /input_dir/ct71_ODV.csv

--- a/recipes/seal-tags/recipe.sh
+++ b/recipes/seal-tags/recipe.sh
@@ -2,4 +2,4 @@
 # feel like one. Each line, unless it starts with #, is interpreted as a
 # workflow step.
 
-ogr2ogr -lco ENCODING=UTF-8 -t_srs "EPSG:3413" -makevalid -s_srs "EPSG:4326" -oo X_POSSIBLE_NAMES=Longitude -oo Y_POSSIBLE_NAMES=Latitutde /output_dir/ct71_ODV_epsg3413.gpkg /input_dir/ct71_ODV.csv
+ogr2ogr -lco ENCODING=UTF-8 -t_srs "EPSG:3413" -makevalid -s_srs "EPSG:4326" -oo X_POSSIBLE_NAMES=Longitude -oo Y_POSSIBLE_NAMES=Latitude /output_dir/ct71_ODV_epsg3413.gpkg /input_dir/ct71_ODV.csv


### PR DESCRIPTION
* Replace `{input_dir}` and `{output_dir}` slugs with `/input_dir/` an
  `/output_dir/`. These are the actual mount locations of data for each command
  that ogdc uses, managed by argo.
* Fixup broken recipe for sea-ice-conc

See also: https://github.com/QGreenland-Net/ogdc-runner/pull/30
